### PR TITLE
Reduce neuro-clash api docker image size

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,25 +1,28 @@
 # use the official Bun image
 # see all versions at https://hub.docker.com/r/oven/bun/tags
-FROM oven/bun:debian as base
+FROM oven/bun:alpine as base
 WORKDIR /usr/src/app
 
 # install dependencies into temp directory
 # this will cache them and speed up future builds
 FROM base AS install
-RUN mkdir -p /temp/dev
+WORKDIR /temp/dev
 COPY package.json bun.lockb /temp/dev/
-RUN cd /temp/dev && bun install --frozen-lockfile
+RUN bun install --frozen-lockfile
 
 # install with --production (exclude devDependencies)
-RUN mkdir -p /temp/prod
+WORKDIR /temp/prod
 COPY package.json bun.lockb /temp/prod/
-RUN cd /temp/prod && bun install --frozen-lockfile --production
+RUN bun install --frozen-lockfile --production
+
+# copy all project files into the image
+WORKDIR /usr/src/app
+COPY . .
 
 # copy node_modules from temp directory
 # then copy all (non-ignored) project files into the image
 FROM base AS prerelease
 COPY --from=install /temp/dev/node_modules node_modules
-COPY . .
 
 # TODO MAYBE?
 # [optional] tests & build
@@ -29,9 +32,10 @@ COPY . .
 
 # copy production dependencies and source code into final image
 FROM base AS release
+WORKDIR /usr/src/app
 COPY --from=install /temp/prod/node_modules node_modules
-COPY --from=prerelease /usr/src/app/src/index.ts .
-COPY --from=prerelease /usr/src/app/package.json .
+COPY src/index.ts .
+COPY package.json .
 
 # run the app
 USER bun

--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "bun --watch ./src/index.ts",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "test": "bun test"
+    "test": "bun test",
+    "build:docker": "docker build --pull -t neuro-clash-api .",
+    "start:docker": "docker run -d -p 5000:5000 neuro-clash-api"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
# 🧠 What is this PR about? 🧠
Decrease docker image size for neuro-clash api by 37.49% to hopefully keep the GCR free tier

Everything should work as normal

## 🖼 Gallery
![image](https://github.com/CognitiveControlLab/neuro-clash/assets/26386997/acf805dd-8baf-4051-9756-f8f449648d71)
![image](https://github.com/CognitiveControlLab/neuro-clash/assets/26386997/165c922a-c168-4a96-b2cc-6952f6f15067)
